### PR TITLE
Improve 1.13+ physics

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 const Vec3 = require('vec3').Vec3
 const AABB = require('./lib/aabb')
 const math = require('./lib/math')
+const features = require('./lib/features')
 
 function Physics (mcData, world) {
+  const supportFeature = feature => features.some(({ name, versions }) => name === feature && versions.includes(mcData.version.majorVersion))
   const blocksByName = mcData.blocksByName
 
   // Block Slipperiness
@@ -36,6 +38,7 @@ function Physics (mcData, world) {
   const physics = {
     gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
     airdrag: (1 - 0.02), // actually (1 - drag)
+    waterGravity: 0.02,
     yawSpeed: 3.0,
     sprintSpeed: 1.3,
     sneakSpeed: 0.3,
@@ -334,7 +337,11 @@ function Physics (mcData, world) {
       applyHeading(entity, strafe, forward, acceleration)
       moveEntity(entity, world, vel.x, vel.y, vel.z)
       vel.y *= inertia
-      vel.y -= 0.02
+      if (supportFeature('independentWaterGravity')) {
+        vel.y -= physics.waterGravity
+      } else if (supportFeature('proportionalWaterGravity')) {
+        vel.y -= physics.gravity / 16
+      }
       vel.x *= inertia
       vel.z *= inertia
 

--- a/index.js
+++ b/index.js
@@ -51,13 +51,13 @@ function Physics (mcData, world) {
     outOfLiquidImpulse: 0.3,
     autojumpCooldown: 10, // ticks (0.5s)
     bubbleColumnSurfaceDrag: {
-      down: -0.03,
+      down: 0.03,
       maxDown: -0.9,
       up: 0.1,
       maxUp: 1.8
     },
     bubbleColumnDrag: {
-      down: -0.03,
+      down: 0.03,
       maxDown: -0.3,
       up: 0.06,
       maxUp: 0.7
@@ -250,19 +250,19 @@ function Physics (mcData, world) {
             } else if (block.type === webId) {
               entity.isInWeb = true
             } else if (block.type === bubblecolumnId) {
-              const drag = !block.getProperties().drag // FIXME: PrismarineJS/prismarine-block#15 remove negation when fixed
+              const drag = block.getProperties().drag
               const aboveBlock = world.getBlock(cursor.offset(0, 1, 0))
               if (aboveBlock && aboveBlock.type === airId) {
                 if (drag) {
                   vel.y = Math.max(physics.bubbleColumnSurfaceDrag.maxDown, vel.y - physics.bubbleColumnSurfaceDrag.down)
                 } else {
-                  Math.min(physics.bubbleColumnSurfaceDrag.maxUp, vel.y - physics.bubbleColumnSurfaceDrag.up)
+                  Math.min(physics.bubbleColumnSurfaceDrag.maxUp, vel.y + physics.bubbleColumnSurfaceDrag.up)
                 }
               } else {
                 if (drag) {
                   vel.y = Math.max(physics.bubbleColumnDrag.maxDown, vel.y - physics.bubbleColumnDrag.down)
                 } else {
-                  vel.y = Math.min(physics.bubbleColumnDrag.maxUp, vel.y - physics.bubbleColumnDrag.up)
+                  vel.y = Math.min(physics.bubbleColumnDrag.maxUp, vel.y + physics.bubbleColumnDrag.up)
                 }
               }
             }
@@ -367,7 +367,7 @@ function Physics (mcData, world) {
   function getRenderedDepth (block) {
     if (!block) return -1
     if (block.type === bubblecolumnId) return 0
-    if (block.getProperties().waterlogged !== undefined && !block.getProperties().waterlogged) return 0 // FIXME: PrismarineJS/prismarine-block#15 remove negation and undefined check when fixed
+    if (block.getProperties().waterlogged) return 0
     if (block.type !== waterId) return -1
     const meta = block.metadata
     return meta >= 8 ? 0 : meta
@@ -416,7 +416,7 @@ function Physics (mcData, world) {
       for (cursor.z = Math.floor(bb.minZ); cursor.z <= Math.floor(bb.maxZ); cursor.z++) {
         for (cursor.x = Math.floor(bb.minX); cursor.x <= Math.floor(bb.maxX); cursor.x++) {
           const block = world.getBlock(cursor)
-          if (block && (block.type === waterId || block.type === bubblecolumnId || (block.getProperties().waterlogged !== undefined && !block.getProperties().waterlogged))) { // FIXME: PrismarineJS/prismarine-block#15 remove negation and undefined check when fixed
+          if (block && (block.type === waterId || block.type === bubblecolumnId || block.getProperties().waterlogged)) {
             const waterLevel = cursor.y + 1 - getLiquidHeightPcent(block)
             if (Math.ceil(bb.maxY) >= waterLevel) {
               isInWater = true

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ function Physics (mcData, world) {
   const lavaId = blocksByName.lava.id
   const ladderId = blocksByName.ladder.id
   const vineId = blocksByName.vine.id
+  const airId = blocksByName.air.id
+  const bubblecolumnId = blocksByName.bubble_column.id
 
   const physics = {
     gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
@@ -47,7 +49,19 @@ function Physics (mcData, world) {
     airborneAcceleration: 0.02,
     defaultSlipperiness: 0.6,
     outOfLiquidImpulse: 0.3,
-    autojumpCooldown: 10 // ticks (0.5s)
+    autojumpCooldown: 10, // ticks (0.5s)
+    bubbleColumnSurfaceDrag: {
+      down: -0.03,
+      maxDown: -0.9,
+      up: 0.1,
+      maxUp: 1.8
+    },
+    bubbleColumnDrag: {
+      down: -0.03,
+      maxDown: -0.3,
+      up: 0.06,
+      maxUp: 0.7
+    }
   }
 
   function getPlayerBB (pos) {
@@ -235,6 +249,22 @@ function Physics (mcData, world) {
               vel.z *= physics.soulsandSpeed
             } else if (block.type === webId) {
               entity.isInWeb = true
+            } else if (block.type === bubblecolumnId) {
+              const drag = block.getProperties().drag
+              const aboveBlock = world.getBlock(cursor.offset(0, 1, 0))
+              if (aboveBlock && aboveBlock.type === airId) {
+                if (drag) {
+                  vel.y = Math.max(physics.bubbleColumnSurfaceDrag.maxDown, vel.y - physics.bubbleColumnSurfaceDrag.down)
+                } else {
+                  Math.min(physics.bubbleColumnSurfaceDrag.maxUp, vel.y - physics.bubbleColumnSurfaceDrag.up)
+                }
+              } else {
+                if (drag) {
+                  vel.y = Math.max(physics.bubbleColumnDrag.maxDown, vel.y - physics.bubbleColumnDrag.down)
+                } else {
+                  vel.y = Math.min(physics.bubbleColumnDrag.maxUp, vel.y - physics.bubbleColumnDrag.up)
+                }
+              }
             }
           }
         }

--- a/lib/features.json
+++ b/lib/features.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "independentWaterGravity",
+    "description": "Water gravity is a constant",
+    "versions": ["1.8", "1.9", "1.10", "1.11", "1.12"]
+  },
+  {
+    "name": "proportionalWaterGravity",
+    "description": "Water gravity is a proportion of normal gravity",
+    "versions": ["1.13", "1.14", "1.15", "1.16"]
+  }
+]

--- a/lib/features.json
+++ b/lib/features.json
@@ -1,12 +1,12 @@
 [
   {
-    "name": "independentWaterGravity",
-    "description": "Water gravity is a constant",
+    "name": "independentLiquidGravity",
+    "description": "Liquid gravity is a constant",
     "versions": ["1.8", "1.9", "1.10", "1.11", "1.12"]
   },
   {
-    "name": "proportionalWaterGravity",
-    "description": "Water gravity is a proportion of normal gravity",
+    "name": "proportionalLiquidGravity",
+    "description": "Liquid gravity is a proportion of normal gravity",
     "versions": ["1.13", "1.14", "1.15", "1.16"]
   }
 ]

--- a/lib/features.json
+++ b/lib/features.json
@@ -8,5 +8,15 @@
     "name": "proportionalLiquidGravity",
     "description": "Liquid gravity is a proportion of normal gravity",
     "versions": ["1.13", "1.14", "1.15", "1.16"]
+  },
+  {
+    "name": "velocityBlocksOnCollision",
+    "description": "Velocity changes are caused by blocks are triggered by collision with the block",
+    "versions": ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14"]
+  },
+  {
+    "name": "velocityBlocksOnTop",
+    "description": "Velocity changes are caused by the block the player is standing on",
+    "versions": ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14"]
   }
 ]

--- a/lib/features.json
+++ b/lib/features.json
@@ -17,6 +17,6 @@
   {
     "name": "velocityBlocksOnTop",
     "description": "Velocity changes are caused by the block the player is standing on",
-    "versions": ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14"]
+    "versions": ["1.15", "1.16"]
   }
 ]

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -26,10 +26,15 @@ function fakePlayer (pos) {
       isInWeb: false,
       isCollidedHorizontally: false,
       isCollidedVertically: false,
-      yaw: 0
+      yaw: 0,
+      effects: {}
     },
     jumpTicks: 0,
-    jumpQueued: false
+    jumpQueued: false,
+    version: '1.13.2',
+    inventory: {
+      items: () => []
+    }
   }
 }
 


### PR DESCRIPTION
- Implements bubble columns
- Makes the water detection recognize bubble columns as still water blocks
- Makes the water detection recognize waterlogged blocks as still water blocks
- Fix MC 1.13+ gravity in water and lava
- Implements honeyblocks
- Implements all physics related effects (JumpBoost, Speed, Slowness, Dolphin's Grace, Slow Falling, Levitation)
- Implements Depth Strider enchantment (NOTE: currently missing the soul speed enchantment due to it missing from mc-data, see PrismarineJS/minecraft-data#325, will open a pr there soon)
- Fixed soulsand slowness being applied multiple times when standing on the edge between 2 soulsand blocks

fixes #11 & fixes #6 