### PR TITLE
Use prismarine-nbt to cleanly handle nbt + fix post-flattening enchants

### DIFF
--- a/index.js
+++ b/index.js
@@ -559,6 +559,7 @@ function Physics (mcData, world) {
 class PlayerState {
   constructor (bot, control) {
     const mcData = require('minecraft-data')(bot.version)
+    const nbt = require('prismarine-nbt')
 
     // Input / Outputs
     this.pos = bot.entity.position.clone()
@@ -596,8 +597,13 @@ class PlayerState {
     }
     // armour enchantments
     const boots = bot.inventory.slots[8]
-    this.depthStrider = boots && boots.nbt && boots.nbt.value.Enchantments && boots.nbt.value.Enchantments.some(x => x.id === mcData.enchantmentsByName.depth_strider.id)
-      ? boots.nbt.value.Enchantments.find(x => x.id === mcData.enchantmentsByName.depth_strider.id).lvl : 0
+    if (boots && boots.nbt) {
+      const enchantments = nbt.simplify(boots.nbt).Enchantments
+      const depthEnchant = enchantments.find(x => x.id === mcData.enchantmentsByName.depth_strider.id || x.id === ('minecraft:' + mcData.enchantmentsByName.depth_strider.name))
+      this.depthStrider = depthEnchant ? depthEnchant.lvl : 0
+    } else {
+      this.depthStrider = 0
+    }
   }
 
   apply (bot) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
+    "prismarine-nbt": "^1.3.0",
     "vec3": "^0.1.6"
   }
 }


### PR DESCRIPTION
This change uses prismarine-nbt to simplify the object down to a common format. I've also found that on mc 1.14+ the "id" property of the enchant is now a string in the format of "minecraft:enchant_name", so ive added support for that as well.
Unfortunately this is still crashing, as it seems like no enchantments data was specified post 1.13.2 in minecraft-data, so enchantmentsByName is null on those versions. This can be fixed for versions 1.14-1.15.2 just by adding the datapath to the 1.13.2 enchantments data (as no enchantments were added in those versions), and can be fixed for 1.16+ by PrismarineJS/minecraft-data#325, as new enchantments were added in that version.
Once minecraft-data is fixed and this is merged, this should fix PrismarineJS/mineflayer#1270