### PR TITLE
Fix climbing and water jump

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,10 +355,14 @@ function Physics (mcData, world) {
       if (isOnLadder(world, pos)) {
         vel.x = math.clamp(-physics.ladderMaxSpeed, vel.x, physics.ladderMaxSpeed)
         vel.z = math.clamp(-physics.ladderMaxSpeed, vel.z, physics.ladderMaxSpeed)
-        vel.y = Math.max(entity.control.jump ? physics.ladderClimbSpeed : vel.y, entity.control.sneak ? 0 : -physics.ladderMaxSpeed)
+        vel.y = Math.max(vel.y, entity.control.sneak ? 0 : -physics.ladderMaxSpeed)
       }
 
       moveEntity(entity, world, vel.x, vel.y, vel.z)
+
+      if (entity.isCollidedHorizontally && isOnLadder(world, pos)) {
+        vel.y = physics.ladderClimbSpeed // climb ladder
+      }
 
       // Apply friction and gravity
       if (entity.levitation > 0) {
@@ -396,7 +400,7 @@ function Physics (mcData, world) {
       vel.x *= horizontalInertia
       vel.z *= horizontalInertia
 
-      if (doesNotCollide(world, pos.offset(vel.x, vel.y + 0.6 - pos.y + lastY, vel.z))) {
+      if (entity.isCollidedHorizontally && doesNotCollide(world, pos.offset(vel.x, vel.y + 0.6 - pos.y + lastY, vel.z))) {
         vel.y = physics.outOfLiquidImpulse // jump out of liquid
       }
     }

--- a/index.js
+++ b/index.js
@@ -360,7 +360,8 @@ function Physics (mcData, world) {
 
       moveEntity(entity, world, vel.x, vel.y, vel.z)
 
-      if (entity.isCollidedHorizontally && isOnLadder(world, pos)) {
+      if (isOnLadder(world, pos) && (entity.isCollidedHorizontally ||
+        (supportFeature('climbUsingJump') && entity.control.jump))) {
         vel.y = physics.ladderClimbSpeed // climb ladder
       }
 

--- a/index.js
+++ b/index.js
@@ -355,14 +355,10 @@ function Physics (mcData, world) {
       if (isOnLadder(world, pos)) {
         vel.x = math.clamp(-physics.ladderMaxSpeed, vel.x, physics.ladderMaxSpeed)
         vel.z = math.clamp(-physics.ladderMaxSpeed, vel.z, physics.ladderMaxSpeed)
-        vel.y = Math.max(vel.y, entity.control.sneak ? 0 : -physics.ladderMaxSpeed)
+        vel.y = Math.max(entity.control.jump ? physics.ladderClimbSpeed : vel.y, entity.control.sneak ? 0 : -physics.ladderMaxSpeed)
       }
 
       moveEntity(entity, world, vel.x, vel.y, vel.z)
-
-      if (entity.isCollidedHorizontally && isOnLadder(world, pos)) {
-        vel.y = physics.ladderClimbSpeed // climb ladder
-      }
 
       // Apply friction and gravity
       if (entity.levitation > 0) {
@@ -400,7 +396,7 @@ function Physics (mcData, world) {
       vel.x *= horizontalInertia
       vel.z *= horizontalInertia
 
-      if (entity.isCollidedHorizontally && doesNotCollide(world, pos.offset(vel.x, vel.y + 0.6 - pos.y + lastY, vel.z))) {
+      if (doesNotCollide(world, pos.offset(vel.x, vel.y + 0.6 - pos.y + lastY, vel.z))) {
         vel.y = physics.outOfLiquidImpulse // jump out of liquid
       }
     }

--- a/lib/features.json
+++ b/lib/features.json
@@ -18,5 +18,10 @@
     "name": "velocityBlocksOnTop",
     "description": "Velocity changes are caused by the block the player is standing on",
     "versions": ["1.15", "1.16"]
+  },
+  {
+    "name": "climbUsingJump",
+    "description": "Entity can climb ladders and vines by pressing jump",
+    "versions": ["1.14", "1.15", "1.16"]
   }
 ]


### PR DESCRIPTION
isCollidedHorizontally checks are redundant and do not behave correctly when occupying climbable or water blocks.

It is now possible to climb blocks and the out of water impulse is applied correctly.
This is what is being described in [PrismarineJS/prismarine-physics#28](https://github.com/PrismarineJS/prismarine-physics/issues/28)