### PR TITLE
fix deleteAttributeModifier function

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -39,8 +39,6 @@ exports.checkAttributeModifier = function (attributes, uuid) {
 }
 
 exports.deleteAttributeModifier = function (attributes, uuid) {
-  for (const modifier of attributes.modifiers) {
-    if (modifier.uuid === uuid) delete attributes.modifiers[modifier]
-  }
+  attributes.modifiers = attributes.modifiers.filter(modifier => modifier.uuid !== uuid)
   return attributes
 }


### PR DESCRIPTION
`attributes.modifiers` is a list of modifiers. The delete keyword is not being used correctly in this case and should be opted out for a better approach such as filter.

The deletion of attributes like this was causing a nasty bug in mineflayer control state:

1) set control state to move forward and sprint
2) call bot.attack
3) set control state for sprint to false
4) observe that the bot is still sprinting

Im sure other attribute bugs were also affected by this incorrect usage of delete modifier.