### PR TITLE
Fixes bot.setControlState('left', true) moves right.

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,8 +354,8 @@ function Physics (mcData, world) {
     const cos = Math.cos(yaw)
 
     const vel = entity.vel
-    vel.x += strafe * cos - forward * sin
-    vel.z += forward * cos + strafe * sin
+    vel.x -= strafe * cos + forward * sin
+    vel.z += forward * cos - strafe * sin
   }
 
   function isOnLadder (world, pos) {


### PR DESCRIPTION
Fixes https://github.com/PrismarineJS/mineflayer/issues/2622.

Tested using https://github.com/PrismarineJS/mineflayer/blob/master/examples/jumper.js and https://github.com/PrismarineJS/mineflayer/blob/master/examples/pathfinder/gps.js

![Fixed Demo - Jumper](https://uwu.whats-th.is/8d69JWk.gif)

Pathfinder is unaffected, this only breaks changes where users have relied on right to move left and vise versa.