### PR TITLE
Fixed airborne movement factor for sprinting

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,8 +376,8 @@ function Physics (mcData, world) {
 
     if (!entity.isInWater && !entity.isInLava) {
       // Normal movement
-      let acceleration = physics.airborneAcceleration
-      let inertia = physics.airborneInertia
+      let acceleration = 0.0
+      let inertia = 0.0
       const blockUnder = world.getBlock(pos.offset(0, -1, 0))
       if (entity.onGround && blockUnder) {
         let playerSpeedAttribute
@@ -405,6 +405,14 @@ function Physics (mcData, world) {
         inertia = (blockSlipperiness[blockUnder.type] || physics.defaultSlipperiness) * 0.91
         acceleration = attributeSpeed * (0.1627714 / (inertia * inertia * inertia))
         if (acceleration < 0) acceleration = 0 // acceleration should not be negative
+      } else {
+        acceleration = physics.airborneAcceleration
+        inertia = physics.airborneInertia
+
+        if (entity.control.sprint) {
+          const airSprintFactor = physics.airborneAcceleration * 0.3
+          acceleration += airSprintFactor
+        }
       }
 
       applyHeading(entity, strafe, forward, acceleration)


### PR DESCRIPTION
The horizontal movement factor for airborne movements while sprinting is not implemented. The result is that the velocity falls off too quickly and the engine will miss long jumps.

In vanilla:
1.18.2
![image](https://user-images.githubusercontent.com/20156451/181845594-e8617914-66ba-4510-9547-019e01b95741.png)
1.7.10
![image](https://user-images.githubusercontent.com/20156451/181845767-9d0ca66f-6445-4179-872b-39f83bc92ec0.png)
