### PR TITLE
Fix 1.19 Water Physics

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function Physics (mcData, world) {
     physics.waterGravity = physics.gravity / 16
     physics.lavaGravity = physics.gravity / 4
   } else {
-    throw new Error("No liquid gravity settings, have you made sure the liquid gravity features are up to date?"); 
+    throw new Error('No liquid gravity settings, have you made sure the liquid gravity features are up to date?')
   }
 
   function getPlayerBB (pos) {

--- a/index.js
+++ b/index.js
@@ -89,6 +89,8 @@ function Physics (mcData, world) {
   } else if (supportFeature('proportionalLiquidGravity')) {
     physics.waterGravity = physics.gravity / 16
     physics.lavaGravity = physics.gravity / 4
+  } else {
+    throw new Error("No liquid gravity settings, have you made sure the liquid gravity features are up to date?"); 
   }
 
   function getPlayerBB (pos) {

--- a/lib/features.json
+++ b/lib/features.json
@@ -7,7 +7,7 @@
   {
     "name": "proportionalLiquidGravity",
     "description": "Liquid gravity is a proportion of normal gravity",
-    "versions": ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18"]
+    "versions": ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19"]
   },
   {
     "name": "velocityBlocksOnCollision",


### PR DESCRIPTION
This PR should resolve PrismarineJS/mineflayer#2796, the issue was that both `lavaGravity` and `waterGravity` were never set because `proportionalLiquidGravity` was not set to yet support 1.19, this later down the line caused issues, especially on line 459 because the statement would be evaluated as `(entity.isInWater ? undefined : undefined) * gravityMultiplier` thus returning NaN, throwing everything off and causing our y value to be NaN when we would send movement packets which caused the bot to be disconnected.