### PR TITLE
Fix 1.17 & 1.18 effect names

### DIFF
--- a/index.js
+++ b/index.js
@@ -646,28 +646,6 @@ function getEnchantmentLevel (mcData, enchantmentName, enchantments) {
   return 0
 }
 
-function getStatusEffectNamesForVersion (supportFeature) {
-  if (supportFeature('effectNamesAreRegistryNames')) {
-    return {
-      jumpBoostEffectName: 'jump_boost',
-      speedEffectName: 'speed',
-      slownessEffectName: 'slowness',
-      dolphinsGraceEffectName: 'dolphins_grace',
-      slowFallingEffectName: 'slow_falling',
-      levitationEffectName: 'levitation'
-    }
-  } else {
-    return {
-      jumpBoostEffectName: 'JumpBoost',
-      speedEffectName: 'Speed',
-      slownessEffectName: 'Slowness',
-      dolphinsGraceEffectName: 'DolphinsGrace',
-      slowFallingEffectName: 'SlowFalling',
-      levitationEffectName: 'Levitation'
-    }
-  }
-}
-
 class PlayerState {
   constructor (bot, control) {
     const mcData = require('minecraft-data')(bot.version)
@@ -694,15 +672,14 @@ class PlayerState {
 
     // effects
     const effects = bot.entity.effects
-    const statusEffectNames = getStatusEffectNamesForVersion(supportFeature)
 
-    this.jumpBoost = getEffectLevel(mcData, statusEffectNames.jumpBoostEffectName, effects)
-    this.speed = getEffectLevel(mcData, statusEffectNames.speedEffectName, effects)
-    this.slowness = getEffectLevel(mcData, statusEffectNames.slownessEffectName, effects)
+    this.jumpBoost = getEffectLevel(mcData, 'JumpBoost', effects)
+    this.speed = getEffectLevel(mcData, 'Speed', effects)
+    this.slowness = getEffectLevel(mcData, 'Slowness', effects)
 
-    this.dolphinsGrace = getEffectLevel(mcData, statusEffectNames.dolphinsGraceEffectName, effects)
-    this.slowFalling = getEffectLevel(mcData, statusEffectNames.slowFallingEffectName, effects)
-    this.levitation = getEffectLevel(mcData, statusEffectNames.levitationEffectName, effects)
+    this.dolphinsGrace = getEffectLevel(mcData, 'DolphinsGrace', effects)
+    this.slowFalling = getEffectLevel(mcData, 'SlowFalling', effects)
+    this.levitation = getEffectLevel(mcData, 'Levitation', effects)
 
     // armour enchantments
     const boots = bot.inventory.slots[8]

--- a/index.js
+++ b/index.js
@@ -650,7 +650,6 @@ class PlayerState {
   constructor (bot, control) {
     const mcData = require('minecraft-data')(bot.version)
     const nbt = require('prismarine-nbt')
-    const supportFeature = makeSupportFeature(mcData)
 
     // Input / Outputs
     this.pos = bot.entity.position.clone()

--- a/lib/features.json
+++ b/lib/features.json
@@ -23,10 +23,5 @@
     "name": "climbUsingJump",
     "description": "Entity can climb ladders and vines by pressing jump",
     "versions": ["1.14", "1.15", "1.17", "1.18"]
-  },
-  {
-    "name": "effectNamesAreRegistryNames",
-    "description": "Status effect names equal to their registry names",
-    "versions": ["1.17", "1.18"]
   }
 ]


### PR DESCRIPTION
This pull request addresses the issue where the usage of different effect names for versions 1.17 and 1.18 results in broken effects since the effect names have been updated in the minecraft-data package (related to PrismarineJS/minecraft-data#528) leading to compatibility problems.

To demonstrate this issue, I have performed a test using the levitation effect in version 1.17.

Without the fix:

https://github.com/PrismarineJS/prismarine-physics/assets/33067100/7d2924a0-e8d9-4987-8e26-d54e2a91f3a9

With the fix:

https://github.com/PrismarineJS/prismarine-physics/assets/33067100/4a4ddbdb-b845-4646-920e-aebe9d221892

Hope this helps, any feedback or suggestions regarding this pull request would be greatly appreciated.