### PR TITLE
Fix incorrect behavior in 1.19+. Improve feature list version condition.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,21 @@ const math = require('./lib/math')
 const features = require('./lib/features')
 const attribute = require('./lib/attribute')
 
+// This class parses features.json
+//
+// The versions field should be an array of conditions, reduced by 'OR'.
+// A condition is one of:
+//  - a major version string, e.g. "1.14", and this match all 1.14.x versions.
+//  - a predicate and a version string separated by a space, e.g. ">= 1.14".
+//  - an array of two types above, reduced by 'AND'.
+// A predicate is one of: [">", ">=", "<", "<=", "=="].
+// NOTE: Condition "== 1.14" only matches "1.14" but not "1.14.1"
+//
+// For example, the version [[">= 1.12", "< 1.14"], "== 1.19.1", "> 1.20"] can match:
+//  - 1.12.X
+//  - 1.13.X
+//  - 1.19.1
+//  - 1.20.1 and above
 class FeatureList {
   static checkVersion (version, condition) {
     const [predicateName, parameter] = condition.split(' ')

--- a/lib/features.json
+++ b/lib/features.json
@@ -2,26 +2,31 @@
   {
     "name": "independentLiquidGravity",
     "description": "Liquid gravity is a constant",
-    "versions": ["1.8", "1.9", "1.10", "1.11", "1.12"]
+    "versions": [[">= 1.8", "<= 1.12"]]
   },
   {
     "name": "proportionalLiquidGravity",
     "description": "Liquid gravity is a proportion of normal gravity",
-    "versions": ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20"]
+    "versions": [">= 1.13"]
   },
   {
     "name": "velocityBlocksOnCollision",
     "description": "Velocity changes are caused by blocks are triggered by collision with the block",
-    "versions": ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14"]
+    "versions": [[">= 1.8", "<= 1.14"]]
   },
   {
     "name": "velocityBlocksOnTop",
     "description": "Velocity changes are caused by the block the player is standing on",
-    "versions": ["1.15", "1.17", "1.18"]
+    "versions": [">= 1.15"]
   },
   {
     "name": "climbUsingJump",
     "description": "Entity can climb ladders and vines by pressing jump",
-    "versions": ["1.14", "1.15", "1.17", "1.18"]
+    "versions": [">= 1.14"]
+  },
+  {
+    "name": "climableTrapdoor",
+    "description": "Trapdoors placed directly above ladders become climable.",
+    "versions": [">= 1.9"]
   }
 ]

--- a/test/feature-list.test.js
+++ b/test/feature-list.test.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+
+const { FeatureList } = require('prismarine-physics')
+const assert = require('node:assert')
+
+const mockFeatures = [{
+  name: 'A',
+  description: 'Simple version requirement',
+  versions: ['== 1.19.2']
+}, {
+  name: 'B',
+  description: 'Simple version requirement',
+  versions: ['== 1.18.1']
+}, {
+  name: 'C',
+  description: 'Multiple version requirement',
+  versions: ['== 1.18.1', '== 1.19.2']
+}, {
+  name: 'D',
+  description: 'Multiple-And version requirement',
+  versions: [['>= 1.13', '< 1.20']]
+}, {
+  name: 'E',
+  description: 'Lagency version requirement',
+  versions: ['1.19']
+}, {
+  name: 'F',
+  description: 'Lagency version requirement',
+  versions: ['1.14']
+}]
+
+describe('Test of FeatureList()', () => {
+  it('Test FeatureList conditions', () => {
+    const mcData = require('minecraft-data')('1.19.2')
+    const supportedFeatureList = new FeatureList(mockFeatures, mcData.version)
+    assert.ok(supportedFeatureList.supportFeature('A'))
+    assert.ok(!supportedFeatureList.supportFeature('B'))
+    assert.ok(supportedFeatureList.supportFeature('C'))
+    assert.ok(supportedFeatureList.supportFeature('D'))
+    assert.ok(supportedFeatureList.supportFeature('E'))
+    assert.ok(!supportedFeatureList.supportFeature('F'))
+  })
+})


### PR DESCRIPTION
The problem: I have noticed the bot cannot climb trapdoors that is directly above ladders (#109). I have also noticed that in 1.20.1 the bot cannot jump to climb ladders (#108).

In this pull request:
- I've added a new feature `climableTrapdoor` to indicate whether the trapdoors is climbable. [Reference: Trapdoor History - Minecraft Wiki](https://minecraft.wiki/w/Trapdoor#History)
- I've added code in function `isOnLadder` to handdle trapdoors.
- I've re-designed the format of `versions` field in `featires.json` (the new format is fully compatible with the old format).
- I've added a new class called `FeatureList` that can parse the new format.
- I've added testcases to test if `FeatureList` is working.

The new version format is described in the comments beside `FeatureList` source:

https://github.com/szdytom/prismarine-physics/blob/c524a9b0e655c472e1ecbb4f2193cb26360e8313/index.js#L7-L21

Fixes #108
Fixes #109