### PR TITLE
Fix `.isOnLadder()` condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -434,6 +434,7 @@ function Physics (mcData, world) {
     vel.z += forward * cos - strafe * sin
   }
 
+  const climbableTrapdoorFeature = supportFeature('climbableTrapdoor')
   function isOnLadder (world, pos) {
     const block = world.getBlock(pos)
     if (!block) { return false }
@@ -443,11 +444,12 @@ function Physics (mcData, world) {
     //  1. The trapdoor is placed directly above a ladder.
     //  2. The trapdoor is opened.
     //  3. The trapdoor and the ladder directly below it face the same direction.
-    if (supportFeature('climbableTrapdoor') && trapdoorIds.has(block.type)) {
+    if (climbableTrapdoorFeature && trapdoorIds.has(block.type)) {
       const blockBelow = world.getBlock(pos.offset(0, -1, 0))
       if (blockBelow.type !== ladderId) { return false } // condition 1.
-      if (!block.getProperties().open) { return false } // condition 2.
-      if (block.getProperties().facing !== blockBelow.getProperties().facing) { return false } // condition 3
+      const blockProperties = block.getProperties()
+      if (!blockProperties.open) { return false } // condition 2.
+      if (blockProperties.facing !== blockBelow.getProperties().facing) { return false } // condition 3
       return true
     }
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,21 @@ function Physics (mcData, world) {
   const lavaIds = [blocksByName.lava.id, blocksByName.flowing_lava ? blocksByName.flowing_lava.id : -1]
   const ladderId = blocksByName.ladder.id
   const vineId = blocksByName.vine.id
+
+  // NOTE: Copper trapdoors is coming in 1.21.
+  const trapdoorIds = new Set()
+  if (blocksByName.iron_trapdoor) { trapdoorIds.add(blocksByName.iron_trapdoor.id) } // 1.8+
+  if (blocksByName.acacia_trapdoor) { trapdoorIds.add(blocksByName.acacia_trapdoor.id) } // 1.13+
+  if (blocksByName.birch_trapdoor) { trapdoorIds.add(blocksByName.birch_trapdoor.id) } // 1.13+
+  if (blocksByName.jungle_trapdoor) { trapdoorIds.add(blocksByName.jungle_trapdoor.id) } // 1.13+
+  if (blocksByName.oak_trapdoor) { trapdoorIds.add(blocksByName.oak_trapdoor.id) } // 1.13+
+  if (blocksByName.dark_oak_trapdoor) { trapdoorIds.add(blocksByName.dark_oak_trapdoor.id) } // 1.13+
+  if (blocksByName.spruce_trapdoor) { trapdoorIds.add(blocksByName.spruce_trapdoor.id) } // 1.13+
+  if (blocksByName.crimson_trapdoor) { trapdoorIds.add(blocksByName.crimson_trapdoor.id) } // 1.16+
+  if (blocksByName.warped_trapdoor) { trapdoorIds.add(blocksByName.warped_trapdoor.id) } // 1.16+
+  if (blocksByName.mangrove_trapdoor) { trapdoorIds.add(blocksByName.mangrove_trapdoor.id) } // 1.19+
+  if (blocksByName.cherry_trapdoor) { trapdoorIds.add(blocksByName.cherry_trapdoor.id) } // 1.20+
+
   const waterLike = new Set()
   if (blocksByName.seagrass) waterLike.add(blocksByName.seagrass.id) // 1.13+
   if (blocksByName.tall_seagrass) waterLike.add(blocksByName.tall_seagrass.id) // 1.13+
@@ -421,7 +436,22 @@ function Physics (mcData, world) {
 
   function isOnLadder (world, pos) {
     const block = world.getBlock(pos)
-    return (block && (block.type === ladderId || block.type === vineId))
+    if (!block) { return false }
+    if (block.type === ladderId || block.type === vineId) { return true }
+
+    // Since 1.9, when a trapdoor satisfies the following conditions, it also becomes climbable:
+    //  1. The trapdoor is placed directly above a ladder.
+    //  2. The trapdoor is opened.
+    //  3. The trapdoor and the ladder directly below it face the same direction.
+    if (supportFeature('climbableTrapdoor') && trapdoorIds.has(block.type)) {
+      const blockBelow = world.getBlock(pos.offset(0, -1, 0))
+      if (blockBelow.type !== ladderId) { return false } // condition 1.
+      if (!block.getProperties().open) { return false } // condition 2.
+      if (block.getProperties().facing !== blockBelow.getProperties().facing) { return false } // condition 3
+      return true
+    }
+
+    return false
   }
 
   function doesNotCollide (world, pos) {

--- a/index.js
+++ b/index.js
@@ -447,7 +447,7 @@ function Physics (mcData, world) {
     if (climbableTrapdoorFeature && trapdoorIds.has(block.type)) {
       const blockBelow = world.getBlock(pos.offset(0, -1, 0))
       if (blockBelow.type !== ladderId) { return false } // condition 1.
-      const blockProperties = block.getProperties()
+      const blockProperties = block._properties
       if (!blockProperties.open) { return false } // condition 2.
       if (blockProperties.facing !== blockBelow.getProperties().facing) { return false } // condition 3
       return true

--- a/lib/features.json
+++ b/lib/features.json
@@ -17,11 +17,16 @@
   {
     "name": "velocityBlocksOnTop",
     "description": "Velocity changes are caused by the block the player is standing on",
-    "versions": ["1.15", "1.17", "1.18"]
+    "versions": ["1.15", "1.16", "1.17", "1.18", "1.19", "1.20"]
   },
   {
     "name": "climbUsingJump",
     "description": "Entity can climb ladders and vines by pressing jump",
-    "versions": ["1.14", "1.15", "1.17", "1.18"]
+    "versions": ["1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20"]
+  },
+  {
+    "name": "climbableTrapdoor",
+    "description": "Trapdoors placed directly above ladders become climbable",
+    "versions": ["1.9", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20"]
   }
 ]


### PR DESCRIPTION
The problem: I have noticed the bot cannot climb trapdoors that is directly above ladders (#109). I have also noticed that in 1.20.1 the bot cannot jump to climb ladders (#108).

In this pull request:
- I've added a new feature `climableTrapdoor` to indicate whether the trapdoors is climbable. [Reference: Trapdoor History - Minecraft Wiki](https://minecraft.wiki/w/Trapdoor#History)
- I've added code in function `isOnLadder` to handdle trapdoors.
- I've added a few missing versions to `features.json`

Fixes #108
Fixes #109
Closes #110