### PR TITLE
fix hitbox issues on newer versions of minecraft

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function Physics (mcData, world) {
           if (block) {
             const blockPos = block.position
             for (const shape of block.shapes) {
-              const blockBB = new AABB(shape[0], shape[1], shape[2], shape[3], shape[4], shape[5])
+              const blockBB = new AABB(shape[0] - 0.01, shape[1], shape[2] - 0.01, shape[3] + 0.01, shape[4], shape[5] + 0.01)
               blockBB.offset(blockPos.x, blockPos.y, blockPos.z)
               surroundingBBs.push(blockBB)
             }


### PR DESCRIPTION
In newer versions of minecraft there are some minor changes to the hitbox system

this wont affect older versions.

examples of the bug:
<img width="326" alt="imagdwae" src="https://github.com/PrismarineJS/prismarine-physics/assets/64040187/d7d65b78-410c-48d8-b1f9-0b474a4ea06b">
![image](https://github.com/PrismarineJS/prismarine-physics/assets/64040187/a8d76431-8cd8-4925-ba2a-5b0469159197)
