### PR TITLE
Add 26.1 to the existing physics feature sets

### DIFF
--- a/lib/features.json
+++ b/lib/features.json
@@ -7,7 +7,7 @@
   {
     "name": "proportionalLiquidGravity",
     "description": "Liquid gravity is a proportion of normal gravity",
-    "versions": ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+    "versions": ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "26.1"]
   },
   {
     "name": "velocityBlocksOnCollision",
@@ -22,7 +22,7 @@
   {
     "name": "climbUsingJump",
     "description": "Entity can climb ladders and vines by pressing jump",
-    "versions": ["1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+    "versions": ["1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "26.1"]
   },
   {
     "name": "climbableTrapdoor",

--- a/test/scaffolding.test.js
+++ b/test/scaffolding.test.js
@@ -7,15 +7,16 @@ const features = require('../lib/features.json')
 
 describe('Scaffolding climbable and climbUsingJump feature', () => {
   describe('features.json', () => {
-    it('climbUsingJump should include version 1.21', () => {
+    it('climbUsingJump should include versions 1.21 and 26.1', () => {
       const climbUsingJump = features.find(f => f.name === 'climbUsingJump')
       expect(climbUsingJump).toBeTruthy()
       expect(climbUsingJump.versions).toContain('1.21')
+      expect(climbUsingJump.versions).toContain('26.1')
     })
 
-    it('climbUsingJump should include versions 1.14 through 1.21', () => {
+    it('climbUsingJump should include versions 1.14 through 1.21 and 26.1', () => {
       const climbUsingJump = features.find(f => f.name === 'climbUsingJump')
-      for (const v of ['1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21']) {
+      for (const v of ['1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '26.1']) {
         expect(climbUsingJump.versions).toContain(v)
       }
     })


### PR DESCRIPTION
## Summary
This updates prismarine-physics for 26.1.

## What changed
- adds `26.1` to the relevant physics feature lists